### PR TITLE
Fixed an error if pdf is signed without tsa defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ token, which will actually timestamp the document. This way Adobe Reader will re
 
 ## usage
 ```
-pdfsign v1.6.0, (c) 2021 Mabulous GmbH
+pdfsign v1.6.1, (c) 2021 Mabulous GmbH
 powered by:
 pdfsign v1.3.0, (c) 2019 icomedias GmbH
 iTextSharp 5.5 Copyright (C) 1999-2018 by iText Group NV

--- a/pdfsign/Properties/AssemblyInfo.cs
+++ b/pdfsign/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.6.0.0")]
+[assembly: AssemblyVersion("1.6.1.0")]
+[assembly: AssemblyFileVersion("1.6.1.0")]


### PR DESCRIPTION
In version 1.6.0 if a pdf is signed without specifying a tsa and not
chaning the ltv argument from the default 'on' to off, the app crashes.
This fixes the problem by deactivating ltv if no tsa url has been
defined.